### PR TITLE
Fixes cowboy_session:expire/1, replaces ossp_uuid with erlang-uuid

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cowboy session
 
 ## Usage:
-First you need to get dependencies (gproc and ossp_uuid) and compile the code:
+First you need to get dependencies (gproc and erlang-uuid) and compile the code:
 ```bash
 make
 ```
@@ -18,7 +18,7 @@ cowboy_session:start().
 or manually
 ```erlang
 application:start(gproc),
-application:start(ossp_uuid),
+application:start(uuid),
 application:start(cowboy_session).
 ```
 

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,5 @@
 {deps, [
 	{gproc, ".*", {git, "git://github.com/esl/gproc.git", {branch, "master"}}},
-	{ossp_uuid, ".*", {git, "git://github.com/yrashk/erlang-ossp-uuid.git", {branch, "master"}}}
+    {uuid, ".*", {git, "git://github.com/travis/erlang-uuid.git",
+             "f6a1cf9027e4af78b4a81201f4f6db1a822b8316"}}
 ]}.

--- a/src/cowboy_session.app.src
+++ b/src/cowboy_session.app.src
@@ -6,7 +6,7 @@
 		kernel,
 		stdlib,
 		gproc,
-		ossp_uuid
+		uuid
 	]},
 	{mod, {cowboy_session, []}},
 	{env, []}

--- a/src/cowboy_session.erl
+++ b/src/cowboy_session.erl
@@ -116,7 +116,9 @@ clear_cookie(Req) ->
 		Req2).
 
 create_session(Req) ->
-	SID = ossp_uuid:make(v4, text),
+	%% The cookie value cannot contain any of the following characters:
+	%%   ,; \t\r\n\013\014
+	SID = list_to_binary(uuid:to_string(uuid:v4())),
 	Cookie_name = ?CONFIG(cookie_name),
 	Cookie_options = ?CONFIG(cookie_options),
 	Storage = ?CONFIG(storage),

--- a/src/cowboy_session_server.erl
+++ b/src/cowboy_session_server.erl
@@ -92,7 +92,7 @@ handle_cast(touch, #state{expire = Expire, expire_tref = Expire_TRef} = State) -
 
 handle_cast(stop, #state{expire_tref = Expire_TRef} = State) ->
 	timer:cancel(Expire_TRef),
-	{stop, stopped, State#state{expire_tref = nil}};
+	{stop, normal, State#state{expire_tref = nil}};
 
 handle_cast(_, State) -> {noreply, State}.
 


### PR DESCRIPTION
- Fixes cowboy_session:expire/1 (for details refer to https://github.com/esl/cowboy_session/commit/ad3138025cff00519e675af19e117e310e7aaf29#commitcomment-8347333)
- Replaces ossp_uuid with the Erlang UUID Module to get rid of NIF-s.
