### PR TITLE
Fix clear_cookie and session_config

### DIFF
--- a/src/cowboy_session_config.erl
+++ b/src/cowboy_session_config.erl
@@ -47,10 +47,15 @@ update_storage(Value) ->
 	end.
 
 get(Key) ->
-	get(Key, undefined).
+	gen_server:call(?MODULE, {get, Key}).
 
 get(Key, Default) ->
-	gen_server:call(?MODULE, {get, Key, Default}).
+	case ?MODULE:get(Key) of
+		{ok, Value} ->
+			{ok, Value};
+		{error, not_found} ->
+			{ok, Default}
+	end.
 
 %% ===================================================================
 %% Gen_server callbacks
@@ -59,12 +64,13 @@ get(Key, Default) ->
 init([]) ->
 	{ok, ?DEFAULT}.
 
-handle_call({get, Key, Default}, _From, State) ->
-	Result = case lists:keyfind(Key, 1, State) of
-		{_, Value} -> Value;
-		_ -> Default
-	end,
-	{reply, Result, State};
+handle_call({get, Key}, _From, State) ->
+	case lists:keyfind(Key, 1, State) of
+		{Key, Value} ->
+			{reply, {ok, Value}, State};
+		false ->
+			{reply, {error, not_found}, State}
+	end;
 handle_call(_Request, _From, State) ->
 	{reply, ignored, State}.
 


### PR DESCRIPTION
Change session_config api to get a
badmatch if the key is supposed to be
in the config, and return a default value
only when explicitly specified.

We found these inconsistencies while running the
dialyzer and changed to avoid returning `undefined`
given that the session_config value could be any term.
